### PR TITLE
Add course formats links and "for individuals whom slides"

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -24,3 +24,12 @@ knitr::write_bib(c(
 # About this Course {-}
 
 This course is part of a series of courses for the [Informatics Technology for Cancer Research (ITCR)](https://itcr.cancer.gov/) called the Informatics Technology for Cancer Research Education Resource. This material was created by the ITCR Training Network (ITN)  which is a collaborative effort of researchers around the United States to support cancer informatics and data science training through resources, technology, and events. This initiative is funded by the following grant:  [National Cancer Institute (NCI)](https://www.cancer.gov/)  UE5 CA254170. Our courses feature tools developed by ITCR Investigators and make it easier for principal investigators, scientists, and analysts to integrate cancer informatics into their workflows. Please see our website at [www.itcrtraining.org](www.itcrtraining.org) for more information.
+
+## Available course formats
+
+This course is available in multiple formats which allows you to take it in the way that best suites your needs. You can take it for certificate which can be for free or fee.
+
+- The material for this course can be viewed without login requirement on this [Bookdown website](https://jhudatascience.org/Adv_Reproducibility_in_Cancer_Informatics/). This format might be most appropriate for you if you rely on screen-reader technology.
+- This course can be taken for [free certification through Leanpub](https://leanpub.com/universities/courses/jhu/adv-reproducibility-in-cancer-informatics).
+- This course can be taken on [Coursera for certification here](https://www.coursera.org/learn/adv-reproducibility-cancer-informatics) (but it is not available for free on Coursera).
+- Our courses are open source, you can find the [source material for this course on GitHub](https://github.com/jhudsl/Adv_Reproducibility_in_Cancer_Informatics).

--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -3,8 +3,10 @@ Avi's
 al
 Avi
 AML
+Bookdown
 Browse’
 Azacytidine
+Coursera
 Decitabine
 dropdown
 et
@@ -61,3 +63,4 @@ Dockerfile's
 GEOquery
 PII
 yaml
+Leanpub


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?

These adds are a part of a series across all current ITCR courses are two fold: 

1) Add course format links so people are aware of the other ways to take the course no matter where they land. 
2) Make it clear up front whom the course is for and what topics are covered by adding in our standard slide cards. 
