### PR TITLE
add ITN favicon and fix links

### DIFF
--- a/03-version-control-with-github.Rmd
+++ b/03-version-control-with-github.Rmd
@@ -243,9 +243,9 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1IJ_uFxJud7OdIAr6
 
 - [Happy Git and GitHub for the useR](https://happygitwithr.com/) by @Bryan2021.
 - [GitHub for data scientists](https://towardsdatascience.com/introduction-to-github-for-data-scientists-2cf8b9b25fba) by @Vickery2019.
-- [Intro to GitHub](https://lab.github.com/githubtraining/introduction-to-github) by @GitHub2021.
-- [First Day on GitHub](https://lab.github.com/githubtraining/first-day-on-github) by @GitHub2021c.
-- [First Week on GitHub](https://lab.github.com/githubtraining/first-week-on-github) by @GitHub2021d.
+- [Intro to GitHub](https://github.com/skills/introduction-to-github) by @GitHub2022.
+- [First Day on GitHub](https://skills.github.com/#first-day-on-github) by @GitHub2022c.
+- [First Week on GitHub](https://skills.github.com/#first-week-on-github) by @GitHub2022d.
 - [GitHub docs about creating a Pull Request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) by @GitHub2021b.
 - [Making a Pull Request](https://www.atlassian.com/git/tutorials/making-a-pull-request) by @Radigan2021.
 

--- a/04-data-handling.Rmd
+++ b/04-data-handling.Rmd
@@ -46,4 +46,4 @@ You can download this [general template download file here](https://raw.githubus
 - [Data download script for multiple files of the same place](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/setup/00-data-download.sh)
 - [Data download script - refine.bio example](https://github.com/jhudsl/reproducible-R-example/blob/main/00-download-data.py)
 
-For more about data sharing techniques, see the <a href="https://jhudatascience.org/Data_Management/data-sharing.html" target="_blank">Computing and Data Management course</a>.
+For more about data sharing techniques, see the [Ethical Data Handling for Cancer Research](https://jhudatascience.org/Ethical_Data_Handling_for_Cancer_Research/) course</a>.

--- a/04-data-handling.Rmd
+++ b/04-data-handling.Rmd
@@ -15,7 +15,7 @@ The first part of any analysis should be getting all the data needed to run it. 
 
 ### Overview of data sharing
 
-- The data to be shared does not contain <a href="https://jhudatascience.org/Data_Management_for_Cancer_Research/data-privacy.html" target="_blank"> PII (personal identifiable information) or PHI (protected health information) information</a>.
+- The data to be shared does not contain [PII (personal identifiable information) or PHI (protected health information) information](https://jhudatascience.org/Ethical_Data_Handling_for_Cancer_Research/data-privacy.html).
 - The data are accessible by a download script that is automatically downloaded when re-running the analysis.
 - Every data file needed to run the analysis is available.
 - The data are downloaded to files in an organized manner. For more about project organization, see [this chapter from the Introduction to Reproducibility course](https://jhudatascience.org/Reproducibility_in_Cancer_Informatics/organizing-your-project.html).

--- a/05-code-review-author.Rmd
+++ b/05-code-review-author.Rmd
@@ -115,7 +115,7 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1IJ_uFxJud7OdIAr6
 
 1. Create a new branch as we described in the previous chapter.
 2. In your local repository, create a folder called `.github`
-3. Cpy and past this [pull request template file](https://raw.githubusercontent.com/jhudsl/Adv_Reproducibility_in_Cancer_Informatics/main/.github/PULL_REQUEST_TEMPLATE.md) to a new text file and save it as a `.md` to get started.
+3. Copy and paste this [pull request template file](https://raw.githubusercontent.com/jhudsl/Adv_Reproducibility_in_Cancer_Informatics/main/.github/PULL_REQUEST_TEMPLATE.md) to a new text file and save it as a `.md` to get started.
 4. Feel free to edit this file to your own needs and add it to the `.github` folder of your repository.
 5. Use GitKraken to `add` and `commit` this new file.
 6. Push this commit.

--- a/05-code-review-author.Rmd
+++ b/05-code-review-author.Rmd
@@ -115,8 +115,8 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1IJ_uFxJud7OdIAr6
 
 1. Create a new branch as we described in the previous chapter.
 2. In your local repository, create a folder called `.github`
-3. Download this [pull request template file](https://raw.githubusercontent.com/jhudsl/Adv_Reproducibility_in_Cancer_Informatics/main/resources/PULL_REQUEST_TEMPLATE.md) to get you started.
-4. Feel free to edit this file to your own needs and add it to the `.github` folder.
+3. Cpy and past this [pull request template file](https://raw.githubusercontent.com/jhudsl/Adv_Reproducibility_in_Cancer_Informatics/main/.github/PULL_REQUEST_TEMPLATE.md) to a new text file and save it as a `.md` to get started.
+4. Feel free to edit this file to your own needs and add it to the `.github` folder of your repository.
 5. Use GitKraken to `add` and `commit` this new file.
 6. Push this commit.
 7. Open up a pull request.

--- a/09-automation.Rmd
+++ b/09-automation.Rmd
@@ -98,7 +98,7 @@ _Tips for developing a GitHub Action:_
 ### Resources for setting up your GitHub Actions
 - [Python example GitHub Actions to re-run notebook](https://github.com/jhudsl/reproducible-python-example/blob/49e1e33ad0c19d59f85d7c6a6ef8cb173cee0661/.github/workflows/run-py-notebook.yml)
 - [R example GitHub Actions to re-run notebook](https://github.com/jhudsl/reproducible-R-example/blob/main/.github/workflows/run-r-notebook.yml)
-- [Great course about GitHub actions](https://lab.github.com/githubtraining/github-actions:-hello-world)
+- [Great course about GitHub actions](https://skills.github.com/#automate-workflows-with-github-actions)
 - [Introduction to GitHub Actions for data scientists](https://towardsdatascience.com/introduction-to-github-actions-7fcb30d0f959).
 
 **If you have any feedback on this chapter, please [fill out this form](https://forms.gle/j3cJZX5CmNtQp6QKA), we'd love to hear your feedback!**

--- a/09-automation.Rmd
+++ b/09-automation.Rmd
@@ -96,7 +96,7 @@ _Tips for developing a GitHub Action:_
 - Use `|` in your `run:` command to give a multi-line command.
 
 ### Resources for setting up your GitHub Actions
-- [Python example GitHub Actions to re-run notebook](https://github.com/jhudsl/reproducible-python-example/blob/main/.github/workflows/run-python-notebook.yml)
+- [Python example GitHub Actions to re-run notebook](https://github.com/jhudsl/reproducible-python-example/blob/49e1e33ad0c19d59f85d7c6a6ef8cb173cee0661/.github/workflows/run-py-notebook.yml)
 - [R example GitHub Actions to re-run notebook](https://github.com/jhudsl/reproducible-R-example/blob/main/.github/workflows/run-r-notebook.yml)
 - [Great course about GitHub actions](https://lab.github.com/githubtraining/github-actions:-hello-world)
 - [Introduction to GitHub Actions for data scientists](https://towardsdatascience.com/introduction-to-github-actions-7fcb30d0f959).

--- a/About.Rmd
+++ b/About.Rmd
@@ -46,7 +46,7 @@ devtools::session_info()
 [Jimin Hwang]: https://www.linkedin.com/in/jimin-hwang-549835142/
 [Jeff Leek]: https://jtleek.com/
 [John Muschelli]: https://johnmuschelli.com/
-[Sarah Wheelan]: https://www.hopkinsmedicine.org/profiles/details/sarah-wheelan
+[Sarah Wheelan]: https://www.linkedin.com/in/sarah-wheelan-782688203/
 
 <!-- Links -->
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This course will teach learners to:
 
 If you are encountering any problems with this course, please file a GitHub issue or contact us at {Some email or web address with a contact form}.
 
-_All materials in this course are licensed [CC-BY](https://tldrlegal.com/license/creative-commons-attribution-(cc)#:~:text=Edit-,Quick%20Summary,-This%20is%20the) and can be repurposed freely with attribution._
+_All materials in this course are licensed [CC-BY](https://creativecommons.org/licenses/by-nc/3.0/us/) and can be repurposed freely with attribution._
 
 ## About example files
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-# Intro to Reproducibility in Cancer Informatics
+# Advanced Reproducibility in Cancer Informatics
 
-[![Render Bookdown and Coursera](https://github.com/jhudsl/OTTR_Template/actions/workflows/render-bookdown.yml/badge.svg)](https://github.com/jhudsl/OTTR_Template/actions/workflows/render-bookdown.yml)
+[![Render Bookdown and Coursera](https://github.com/jhudsl/Adv_Reproducibility_in_Cancer_Informatics/actions/workflows/render-all.yml/badge.svg)](https://github.com/jhudsl/Adv_Reproducibility_in_Cancer_Informatics/actions/workflows/render-all.yml/badge.svg)
 
 This course was created from [this GitHub template](https://github.com/jhudsl/OTTR_Template) and is the second part of the two part Reproducibility course. The first [part of the course is here](https://github.com/jhudsl/Reproducibility_in_Cancer_Informatics).
 
@@ -11,10 +11,10 @@ If you would like to contribute to this course material, take a look at the [get
 
 ## About this course
 
-This course introduces the concepts of reproducibility and replicability in the context of cancer informatics.
-It is the first course in a two part course on reproducibility (the second part is not yet written but coming soon).
+This course introduces deeper concepts of reproducibility and replicability in the context of cancer informatics.
+It is the second course in a two part course on reproducibility.
 It uses hands-on exercises to demonstrate in practical terms how to increase the reproducibility of data analyses.
-The course also introduces tools relevant to reproducibility including analysis notebooks, package management, git and GitHub.
+The course also introduces tools relevant to reproducibility including analysis git and GitHub, GitHub Actions, Docker, and more.
 
 ## Learning Objectives
 
@@ -33,29 +33,27 @@ If you are encountering any problems with this course, please file a GitHub issu
 
 _All materials in this course are licensed [CC-BY](https://tldrlegal.com/license/creative-commons-attribution-(cc)) and can be repurposed freely with attribution._
 
-## About the chapter example files
+## About example files
 
-Each chapter has its own zip file to be downloaded as a learner is going through a particular chapter.
+There are files that can be downloaded for learners to work through examples.
 
 There are the Python and R versions.
-For example, for chapter 2 there are:
-```
-python-examples/python-heatmap-adv-chapt-2
-r-examples/r-heatmap-adv-chapt-2
+
 ```
 These files are zipped up by a GitHub action so they are ready for easy downloading by the learner.
-The user will download these according to the chapter and follow along with the chapter to make them more reproducible and eventually hopefully have something that looks like the "final" reproducible example versions.
+The user will download these follow along with the chapter to make them more reproducible and eventually hopefully have something that looks like the "final" reproducible example versions.
 
-This is the URL pattern they can find the chapter files at:
+This is the URL pattern they can find the chapter files at (where there is a **download** button on these pages):
 
 _For Python_:
 ```
-https://github.com/jhudsl/Reproducibility_in_Cancer_Informatics/raw/main/chapter-zips/python-heatmap-chapt-4.zip
+https://github.com/jhudsl/Adv_Reproducibility_in_Cancer_Informatics/blob/main/chapter-zips/reproducible-python-example.zip
 ```
 _For R_:
 ```
-https://github.com/jhudsl/Reproducibility_in_Cancer_Informatics/raw/main/chapter-zips/r-heatmap-chapt-4.zip
+https://github.com/jhudsl/Adv_Reproducibility_in_Cancer_Informatics/blob/main/chapter-zips/reproducible-R-example.zip
 ```
+
 
 ## Obtaining the "final" versions of the example reproducible analyses
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This course will teach learners to:
 
 If you are encountering any problems with this course, please file a GitHub issue or contact us at {Some email or web address with a contact form}.
 
-_All materials in this course are licensed [CC-BY](https://tldrlegal.com/license/creative-commons-attribution-(cc)) and can be repurposed freely with attribution._
+_All materials in this course are licensed [CC-BY](https://tldrlegal.com/license/creative-commons-attribution-(cc)#:~:text=Edit-,Quick%20Summary,-This%20is%20the) and can be repurposed freely with attribution._
 
 ## About example files
 

--- a/book.bib
+++ b/book.bib
@@ -394,7 +394,6 @@
 }
 
 @online{GitHub2022d,
-	author = {The GitHub Training Team},
 	title = {First {Week} on {GitHub}},
 	url = {https://skills.github.com/#first-week-on-github},
 	abstract = {After you've mastered the basics, learn some of the fun things you can do on GitHub. From GitHub Pages to building projects with your friends, this path will give you plenty of new ideas.},

--- a/book.bib
+++ b/book.bib
@@ -385,7 +385,6 @@
 }
 
 @online{GitHub2022c,
-	author = {The GitHub Training Team},
 	title = {First {Day} on {GitHub}},
 	url = {https://skills.github.com/#first-day-on-github},
 	abstract = {Welcome to GitHub! We're so glad you're here. We know it can look overwhelming at first, so we've put together a few of our favorite courses for people logging in for the first time},

--- a/book.bib
+++ b/book.bib
@@ -384,7 +384,7 @@
 	year = {2021},
 }
 
-@misc{GitHub2022c,
+@online{GitHub2022c,
 	author = {The GitHub Training Team},
 	title = {First {Day} on {GitHub}},
 	url = {https://skills.github.com/#first-day-on-github},

--- a/book.bib
+++ b/book.bib
@@ -394,7 +394,7 @@
 	year = {2022}
 }
 
-@misc{GitHub2022d,
+@online{GitHub2022d,
 	author = {The GitHub Training Team},
 	title = {First {Week} on {GitHub}},
 	url = {https://skills.github.com/#first-week-on-github},

--- a/book.bib
+++ b/book.bib
@@ -364,14 +364,14 @@
 	year = {2021},
 }
 
-@misc{GitHub2021,
+@misc{GitHub2022,
 	title = {Introduction to {GitHub}},
-	url = {https://lab.github.com/githubtraining/introduction-to-github},
+	url = {https://github.com/skills/introduction-to-github},
 	abstract = {If you are looking for a quick and fun introduction to GitHub, you've found it. This class will get you started using GitHub in less than an hour.},
 	language = {en},
-	urldate = {2021-11-15},
+	urldate = {2022-12-12},
 	journal = {GitHub Learning Lab},
-	year = {2021},
+	year = {2022},
 }
 
 @misc{GitHub2021b,
@@ -384,26 +384,24 @@
 	year = {2021},
 }
 
-@misc{GitHub2021c,
+@misc{GitHub2022c,
 	author = {The GitHub Training Team},
 	title = {First {Day} on {GitHub}},
-	url = {https://lab.github.com/githubtraining/first-day-on-github},
+	url = {https://skills.github.com/#first-day-on-github},
 	abstract = {Welcome to GitHub! We're so glad you're here. We know it can look overwhelming at first, so we've put together a few of our favorite courses for people logging in for the first time},
 	language = {en},
-	urldate = {2021-11-30},
-	year = {2021},
-	journal = {GitHub Learning Lab},
+	urldate = {2022-12-12},
+	year = {2022}
 }
 
-@misc{GitHub2021d,
+@misc{GitHub2022d,
 	author = {The GitHub Training Team},
 	title = {First {Week} on {GitHub}},
-	url = {https://lab.github.com/githubtraining/first-week-on-github},
+	url = {https://skills.github.com/#first-week-on-github},
 	abstract = {After you've mastered the basics, learn some of the fun things you can do on GitHub. From GitHub Pages to building projects with your friends, this path will give you plenty of new ideas.},
 	language = {en},
-	urldate = {2021-11-30},
-	year = {2021},
-	journal = {GitHub Learning Lab},
+	urldate = {2022-12-12},
+	year = {2022}
 }
 
 @misc{Goldberg2016,

--- a/index.Rmd
+++ b/index.Rmd
@@ -7,7 +7,7 @@ bibliography: [book.bib, packages.bib]
 biblio-style: apalike
 link-citations: yes
 description: "Description about Course/Book."
-favicon: assets/dasl_favicon.ico
+favicon: assets/ITN_favicon.ico
 output:
     bookdown::word_document2:
       toc: true


### PR DESCRIPTION
Modifying index file to update the favicon. I noticed this when I was showing your course of to someone today ;)

Also fixing links that I found to be out of date- this resolves #53  and resolves #55  - github changed several of their links and my course has a different name, and Sarah isn't at JHU anymore, and the license link has a parenthesis that was throwing it off - so I found a new link to describe the license. I think our recent OTTR updates should fix that but did this just in case. I also noticed that the badge was for the template, so I made it for this repo.


Also updating the README which seems to still be for the first course of the series in a couple of spots.